### PR TITLE
Add basic pointInPoly test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Digger
+
+## Running tests
+
+1. Ensure you have [Node.js](https://nodejs.org/) installed (v18 or newer).
+2. From the repository root, run:
+
+```bash
+npm test
+```
+
+This uses Node's built-in test runner to execute files in the `tests/` directory.

--- a/js/world.js
+++ b/js/world.js
@@ -181,7 +181,7 @@ export function getBlockUnderMouse(mx, my) {
 
 
 // Algoritmo ray-casting para saber si (px,py) está dentro de polígono 'poly'
-function pointInPoly(px, py, poly) {
+export function pointInPoly(px, py, poly) {
   let inside = false;
   for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
     let xi = poly[i].x, yi = poly[i].y;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/pointInPoly.test.js
+++ b/tests/pointInPoly.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+global.window = global.window || {};
+
+const { pointInPoly } = await import('../js/world.js');
+
+const square = [
+  { x: 0, y: 0 },
+  { x: 10, y: 0 },
+  { x: 10, y: 10 },
+  { x: 0, y: 10 }
+];
+
+test('returns true for a point inside the polygon', () => {
+  assert.strictEqual(pointInPoly(5, 5, square), true);
+});
+
+test('returns false for a point outside the polygon', () => {
+  assert.strictEqual(pointInPoly(15, 5, square), false);
+});


### PR DESCRIPTION
## Summary
- export `pointInPoly` from `world.js`
- add Node test for `pointInPoly`
- document running tests
- provide npm config for ES modules and test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872060b689c8333b838106ea3ac102a